### PR TITLE
Emploee section and Atendance section bug fixed

### DIFF
--- a/application/models/Employee_model.php
+++ b/application/models/Employee_model.php
@@ -345,6 +345,9 @@ public function getlastid()
   $code= $result->em_code;
   $c=array();
   $c=explode('C',$code);
+  if(!isset($c[1])){
+    $c[1] = null;
+  }
   $code=$c[1]+1;
   return "TTC".$code;
 


### PR DESCRIPTION
I have written a code in **Employee_Model.php**
` if(!isset($c[1])){
    $c[1] = null;
  }
`
at line 348.
![add employee before](https://user-images.githubusercontent.com/75746412/159960333-779ff073-2652-4ab3-8faa-340119269965.PNG)

Render error occurring where `$c` is undefined offset:1 

![add employee after](https://user-images.githubusercontent.com/75746412/159961143-d0719952-c319-47fb-b0c8-fad938f0d3fc.PNG)

After adding the code `$c = null` undefined offset error fixed if `$c[1]` is not set 